### PR TITLE
Change cinema_scope's submodule URL to match the others

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/cinemascience/cinema_components
 [submodule "viewers/cinema_scope"]
 	path = viewers/cinema_scope
-	url = git@github.com:cinemascience/cinema_scope.git
+	url = https://github.com/cinemascience/cinema_scope


### PR DESCRIPTION
@dhrogers When updating submodules in the base cinema repo I was getting:
```console
[stam]$ git submodule update --init --recursive
...
fatal: clone of 'git@github.com:cinemascience/cinema_scope.git' into submodule path '/path/to/cinema/viewers/cinema_scope' failed
Failed to clone 'viewers/cinema_scope'. Retry scheduled
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Updating to the URL in this commit allows it to be cloned like the other submodules.